### PR TITLE
flake: add openstreetmaps as a nixosModule output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,9 @@
   outputs = { self, nixpkgs }: {
     packages.x86_64-linux.default = self.nixosConfigurations.osm.config.system.build.vm;
 
+    nixosModules.openstreetmap = import ./openstreetmap.nix;
+    nixosModule = import ./openstreetmap.nix;
+
     nixosConfigurations.osm = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
       modules = [


### PR DESCRIPTION
This makes it possible for people to use this flake in their own nixos setups instead of having to copy paste the openstreetmaps.nix file